### PR TITLE
Double-escape otpauth URL paramaters passed to Google Charts API

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -225,9 +225,8 @@ speakeasy.generate_key = function(options) {
   // generate a QR code for use in Google Authenticator if requested
   // (Google Authenticator has a special style and requires base32)
   if (google_auth_qr) {
-    // first, make sure that the name doesn't have spaces, since Google Authenticator doesn't like them
-    name = name.replace(/ /g,'');
-    SecretKey.google_auth_qr = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://totp/' + encodeURIComponent(name) + '%3Fsecret=' + encodeURIComponent(SecretKey.base32);
+    var otpauthURL = 'otpauth://totp/' + encodeURIComponent( name ) + '?secret=' + encodeURIComponent( SecretKey.base32 );
+    SecretKey.google_auth_qr = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=' + encodeURIComponent( otpauthURL );
   }
 
   return SecretKey;


### PR DESCRIPTION
This allows for spaces/special chars in the "name" parameter. A better solution than simply removing the spaces (and not dealing with other characters properly. like "&").