### PR TITLE
Fix HOTP calculate value length less then require digit

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -91,15 +91,17 @@ speakeasy.hotp = function(options) {
                 |(digest_bytes[offset+1] & 0xff) << 16
                 |(digest_bytes[offset+2] & 0xff) << 8
                 |(digest_bytes[offset+3] & 0xff);
-
-  bin_code = bin_code.toString();
-
-  // get the chars at position bin_code - length through length chars
-  var sub_start = bin_code.length - length;
-  var code = bin_code.substr(sub_start, length);
   
-  // we now have a code with `length` number of digits, so return it
-  return(code);
+  // Return D = Snum mod 10^Digit
+  bin_code = bin_code % Math.pow(10, length)
+  bin_code = bin_code.toString();
+  // Digit = 7 or more SHOULD be considered in order to extract a longer HOTP value
+  while (bin_code.length < length){
+    bin_code = '0' + bin_code
+  }
+
+  return bin_code
+
 }
 
 // speakeasy.totp(options)


### PR DESCRIPTION
According to [ rfc4226](http://tools.ietf.org/html/rfc4226) specification 5.3, Digit = 7 or more SHOULD be considered in order to extract a longer HOTP value. But we fail to do this, for example:  

```
speakeasy.hotp {key: 'PV5H2NBQEZ4XGU3RPAZUSOLEPVZCIR3OMMXWQPTQN4ZT6UCMHI7Q', counter: 46061050, length: 8, encoding: 'base32'}  
```
not  return '08197819', it return '9' .
