### PR TITLE
Fix encoding issues, RFC4226 discrepancies

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -94,9 +94,7 @@ speakeasy.hotp = function(options) {
 
   bin_code = bin_code.toString();
 
-  // get the chars at position bin_code - length through length chars
-  var sub_start = bin_code.length - length;
-  var code = bin_code.substr(sub_start, length);
+  code = bin_code % Math.pow(10, length)
 
   // we now have a code with `length` number of digits, so return it
   return(code);


### PR DESCRIPTION
I encountered insane UTF8/ASCII issues with Google-provided base32 keys - some kind of encoding issue took place due to the fact that the key buffer was not properly initialized as an ASCII buffer.

This patch fixes the ASCII buffer issue, allowing otp generation to work consistently.

This patch also implements truncation as per RFC4226 instead of using substrings.
