### PR TITLE
Add options for generating key in order to include hotp counter and issuer in QR code

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -1,6 +1,6 @@
 // # speakeasy
 // ### HMAC One-Time Password module for Node.js, supporting counter-based and time-based moving factors
-// 
+//
 // speakeasy makes it easy to implement HMAC one-time passwords, supporting both counter-based (HOTP)
 // and time-based moving factors (TOTP). It's useful for implementing two-factor authentication.
 // Google and Amazon use TOTP to generate codes for use with multi-factor authentication.
@@ -54,7 +54,7 @@ speakeasy.hotp = function(options) {
 
   // init hmac with the key
   var hmac = crypto.createHmac('sha1', new Buffer(key));
-  
+
   // create an octet array from the counter
   var octet_array = new Array(8);
 
@@ -85,7 +85,7 @@ speakeasy.hotp = function(options) {
   // compute HOTP
   // get offset
   var offset = digest_bytes[19] & 0xf;
-  
+
   // calculate bin_code (RFC4226 5.4)
   var bin_code = (digest_bytes[offset] & 0x7f)   << 24
                 |(digest_bytes[offset+1] & 0xff) << 16
@@ -97,7 +97,7 @@ speakeasy.hotp = function(options) {
   // get the chars at position bin_code - length through length chars
   var sub_start = bin_code.length - length;
   var code = bin_code.substr(sub_start, length);
-  
+
   // we now have a code with `length` number of digits, so return it
   return(code);
 }
@@ -113,7 +113,7 @@ speakeasy.hotp = function(options) {
 //        .step(=30)            override the step in seconds
 //        .time                 (optional) override the time to calculate with
 //        .initial_time         (optional) override the initial time
-//        
+//
 speakeasy.totp = function(options) {
   // set vars
   var key = options.key;
@@ -121,10 +121,10 @@ speakeasy.totp = function(options) {
   var encoding = options.encoding || 'ascii';
   var step = options.step || 30;
   var initial_time = options.initial_time || 0; // unix epoch by default
-  
+
   // get current time in seconds since unix epoch
   var time = parseInt(Date.now()/1000);
-  
+
   // are we forcing a specific time?
   if (options.time) {
     // override the time
@@ -133,7 +133,7 @@ speakeasy.totp = function(options) {
 
   // calculate counter value
   var counter = Math.floor((time - initial_time)/ step);
-  
+
   // pass to hotp
   var code = this.hotp({key: key, length: length, encoding: encoding, counter: counter});
 
@@ -167,7 +167,7 @@ speakeasy.hex_to_ascii = function(str) {
 //
 speakeasy.ascii_to_hex = function(str) {
   var hex_string = '';
-  
+
   for (var i = 0; i < str.length; i++) {
     hex_string += str.charCodeAt(i).toString(16);
   }
@@ -192,7 +192,9 @@ speakeasy.ascii_to_hex = function(str) {
 //                                  with the Google Authenticator app.
 //        .name                     (optional) add a name. no spaces.
 //                                  for use with Google Authenticator
-//
+//        .type                     (optional) totp or hotp
+//        .counter                  (optional) default counter value
+//        .issuer                   (optional) default issuer
 speakeasy.generate_key = function(options) {
   // options
   var length = options.length || 32;
@@ -200,6 +202,10 @@ speakeasy.generate_key = function(options) {
   var qr_codes = options.qr_codes || false;
   var google_auth_qr = options.google_auth_qr || false;
   var symbols = true;
+  var type = options.type || 'totp';
+  var counter = options.counter || false;
+  var issuer = options.counter || false;
+
 
   // turn off symbols only when explicity told to
   if (options.symbols !== undefined && options.symbols === false) {
@@ -208,28 +214,33 @@ speakeasy.generate_key = function(options) {
 
   // generate an ascii key
   var key = this.generate_key_ascii(length, symbols);
-  
+
   // return a SecretKey with ascii, hex, and base32
   var SecretKey = {};
   SecretKey.ascii = key;
   SecretKey.hex = this.ascii_to_hex(key);
   SecretKey.base32 = base32.encode(key).replace(/=/g,'');
-  
+
   // generate some qr codes if requested
   if (qr_codes) {
     SecretKey.qr_code_ascii = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=' + encodeURIComponent(SecretKey.ascii);
     SecretKey.qr_code_hex = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=' + encodeURIComponent(SecretKey.hex);
     SecretKey.qr_code_base32 = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=' + encodeURIComponent(SecretKey.base32);
   }
-  
+
   // generate a QR code for use in Google Authenticator if requested
   // (Google Authenticator has a special style and requires base32)
   if (google_auth_qr) {
     // first, make sure that the name doesn't have spaces, since Google Authenticator doesn't like them
     name = name.replace(/ /g,'');
-    SecretKey.google_auth_qr = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://totp/' + encodeURIComponent(name) + '%3Fsecret=' + encodeURIComponent(SecretKey.base32);
+    SecretKey.google_auth_qr = 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://'+type+'/' + encodeURIComponent(name) + '%3Fsecret=' + encodeURIComponent(SecretKey.base32);
   }
-
+  if(issuer){
+    SecretKey.google_auth_qr += '&issuer='+encodeURIComponent(issuer);
+  }
+  if(counter){
+    SecretKey.google_auth_qr = '&counter='+encodeURIComponent(counter);
+  }
   return SecretKey;
 }
 
@@ -247,13 +258,13 @@ speakeasy.generate_key_ascii = function(length, symbols) {
   if (symbols) {
     set += '!@#$%^&*()<>?/[]{},.:;';
   }
-  
+
   var key = '';
 
   for(var i=0; i < length; i++) {
     key += set.charAt(Math.floor(Math.random() * set.length));
   }
-  
+
   return key;
 }
 

--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -204,7 +204,7 @@ speakeasy.generate_key = function(options) {
   var symbols = true;
   var type = options.type || 'totp';
   var counter = options.counter || false;
-  var issuer = options.counter || false;
+  var issuer = options.issuer || false;
 
 
   // turn off symbols only when explicity told to
@@ -239,7 +239,7 @@ speakeasy.generate_key = function(options) {
     SecretKey.google_auth_qr += '&issuer='+encodeURIComponent(issuer);
   }
   if(counter){
-    SecretKey.google_auth_qr = '&counter='+encodeURIComponent(counter);
+    SecretKey.google_auth_qr += '&counter='+encodeURIComponent(counter);
   }
   return SecretKey;
 }


### PR DESCRIPTION

//        .type                     (optional) totp or hotp
//        .counter                  (optional) default counter value
//        .issuer                   (optional) default issuer