### PR TITLE
SHA256 and SHA512 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Written to follow [RFC 4226](http://tools.ietf.org/html/rfc4226). Calculated wit
 * `counter`: the counter position (moving factor). `C` in the algorithm.
 * `length` (default `6`): the length of the resulting one-time password.
 * `encoding` (default `ascii`): the encoding of the `key`. Can be `'ascii'`, `'hex'`, or `'base32'`. The key will automatically be converted to ASCII.
+* `algorithm` (default `sha1`): the hash algorithm to use. Can be `'sha1'`, `'sha256'`, or `'sha512'`
 
 #### Example
 
@@ -92,6 +93,7 @@ Written to follow [RFC 6238](http://tools.ietf.org/html/rfc6238). Calculated wit
 * `initial_time` (default `0`): the starting time where we calculate the TOTP from. Usually, this is set to the UNIX epoch at 0. `T0` in the algorithm.
 * `length` (default `6`): the length of the resulting one-time password.
 * `encoding` (default `ascii`): the encoding of the `key`. Can be `'ascii'`, `'hex'`, or `'base32'`. The key will automatically be converted to ASCII.
+* `algorithm` (default `sha1`): the hash algorithm to use. Can be `'sha1'`, `'sha256'`, or `'sha512'`
 
 #### Example
 

--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -37,6 +37,7 @@ var speakeasy = {}
 //        .counter              moving factor
 //        .length(=6)           length of the one-time password (default 6)
 //        .encoding(='ascii')   key encoding (ascii, hex, or base32)
+//        .algorithm(='sha1')   encytion algorithm (sha1, sha256)
 //
 speakeasy.hotp = function(options) {
   // set vars
@@ -44,16 +45,29 @@ speakeasy.hotp = function(options) {
   var counter = options.counter;
   var length = options.length || 6;
   var encoding = options.encoding || 'ascii';
+  var algorithm = options.algorithm || 'sha1';
+  var hash_size = 160; // sha1
 
-  // preprocessing: convert to ascii if it's not
-  if (encoding == 'hex') {
-    key = speakeasy.hex_to_ascii(key);
-  } else if (encoding == 'base32') {
-    key = base32.decode(key);
+  if (algorithm === 'sha256') {
+    hash_size = 256;
+  } else if (algorithm === 'sha512') {
+    hash_size = 512;
   }
 
+  // preprocessing: convert to buffer
+  if (encoding == 'hex') {
+    key = new Buffer(speakeasy.hex_to_ascii(key));
+  } else if (encoding == 'base32') {
+    key = new Buffer(base32.decode(key));
+  } else {
+    key = new Buffer(key);
+  }
+
+  // repeat the key to the minumum length
+  key = new Buffer(Array(8).join(key.toString('hex')), 'hex').slice(0, hash_size/8);
+
   // init hmac with the key
-  var hmac = crypto.createHmac('sha1', new Buffer(key));
+  var hmac = crypto.createHmac(algorithm, key);
   
   // create an octet array from the counter
   var octet_array = new Array(8);
@@ -84,7 +98,7 @@ speakeasy.hotp = function(options) {
 
   // compute HOTP
   // get offset
-  var offset = digest_bytes[19] & 0xf;
+  var offset = digest_bytes[(hash_size/8 - 1)] & 0xf;
   
   // calculate bin_code (RFC4226 5.4)
   var bin_code = (digest_bytes[offset] & 0x7f)   << 24
@@ -113,6 +127,7 @@ speakeasy.hotp = function(options) {
 //        .step(=30)            override the step in seconds
 //        .time                 (optional) override the time to calculate with
 //        .initial_time         (optional) override the initial time
+//        .algorithm            (optional) override the default algorighm (default sha1)
 //        
 speakeasy.totp = function(options) {
   // set vars
@@ -121,6 +136,7 @@ speakeasy.totp = function(options) {
   var encoding = options.encoding || 'ascii';
   var step = options.step || 30;
   var initial_time = options.initial_time || 0; // unix epoch by default
+  var algorithm = options.algorithm || 'sha1';
   
   // get current time in seconds since unix epoch
   var time = parseInt(Date.now()/1000);
@@ -135,7 +151,7 @@ speakeasy.totp = function(options) {
   var counter = Math.floor((time - initial_time)/ step);
   
   // pass to hotp
-  var code = this.hotp({key: key, length: length, encoding: encoding, counter: counter});
+  var code = this.hotp({key: key, length: length, encoding: encoding, counter: counter, algorithm: algorithm});
 
   // return the code
   return(code);

--- a/test/test_hotp.js
+++ b/test/test_hotp.js
@@ -56,4 +56,35 @@ vows.describe('HOTP Counter-Based Algorithm Test').addBatch({
       assert.equal(topic, '338314');
     }
   },
+
+  'Test base32 encoding with key = \'1234567890\' at counter 3': {
+    topic: function() {
+      return speakeasy.hotp({key: '1234567890', counter: 3});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '969429');
+    }
+  },
+
+  'Test base32 encoding with key = \'GEZDGNBVGY3TQOJQ\' as base32 at counter 1, length = 8 and algorithm as \'sha256\'': {
+    topic: function() {
+      return speakeasy.hotp({key: 'GEZDGNBVGY3TQOJQ', encoding: 'base32', counter: 1, length: 8, algorithm: 'sha256'});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '46119246');
+    }
+  },
+
+  'Test base32 encoding with key = \'GEZDGNBVGY3TQOJQ\' as base32 at counter 1, length = 8 and algorithm as \'sha512\'': {
+    topic: function() {
+      return speakeasy.hotp({key: 'GEZDGNBVGY3TQOJQ', encoding: 'base32', counter: 1, length: 8, algorithm: 'sha512'});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '90693936');
+    }
+  },
+
 }).exportTo(module);

--- a/test/test_totp.js
+++ b/test/test_totp.js
@@ -77,4 +77,34 @@ vows.describe('TOTP Time-Based Algorithm Test').addBatch({
       assert.equal(topic, '755224');
     }
   },
+
+  'Test base32 encoding with key = \'1234567890\' at time = 1111111109': {
+    topic: function() {
+      return speakeasy.totp({key: '1234567890', time: 1111111109});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '081804');
+    }
+  },
+
+  'Test base32 encoding with key = \'GEZDGNBVGY3TQOJQ\' as base32 at time = 1111111109, length = 8 and algorithm as \'sha256\'': {
+    topic: function() {
+      return speakeasy.totp({key: 'GEZDGNBVGY3TQOJQ', encoding: 'base32', time: 1111111109, length: 8, algorithm: 'sha256'});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '68084774');
+    }
+  },
+
+  'Test base32 encoding with key = \'GEZDGNBVGY3TQOJQ\' as base32 at time = 1111111109, length = 8 and algorithm as \'sha512\'': {
+    topic: function() {
+      return speakeasy.totp({key: 'GEZDGNBVGY3TQOJQ', encoding: 'base32', time: 1111111109, length: 8, algorithm: 'sha512'});
+    },
+    
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '25091201');
+    }
+  },
 }).exportTo(module);


### PR DESCRIPTION
- Added support for SHA256 and SHA512
- Added support for repetition of the key to the length of the hashing algorithm (20 bytes for SHA1, 32 bytes for SHA256, 64 bytes for SHA512)
- Added tests for SHA256 and SHA512 test vectors as described in: https://tools.ietf.org/html/rfc6238#appendix-B