### PR TITLE
Fixed random key generation overflow

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -268,7 +268,7 @@ speakeasy.generate_key_ascii = function(length, symbols) {
 
   var output = '';
   for (var i = 0, l = bytes.length; i < l; i++) {
-    output += set[~~(bytes[i] / 0xFF * set.length)];
+    output += set[Math.floor(bytes[i] / 255.0 * (set.length-1))];
   }
   return output;
 };


### PR DESCRIPTION
Problem was that encoded key did not have the right length. Sometimes the expression overflew as max index could be over passed.