### PR TITLE
Remove bias when generating secrets

### DIFF
--- a/index.js
+++ b/index.js
@@ -511,13 +511,13 @@ exports.generateSecret = function generateSecret (options) {
   }
 
   // generate an ascii key
-  var key = this.generateSecretASCII(length, symbols);
+  var keyBytes = crypto.randomBytes(length || 32);
 
   // return a SecretKey with ascii, hex, and base32
   var SecretKey = {};
-  SecretKey.ascii = key;
-  SecretKey.hex = Buffer(key, 'ascii').toString('hex');
-  SecretKey.base32 = base32.encode(Buffer(key)).toString().replace(/=/g, '');
+  SecretKey.ascii = encodeASCII(keyBytes, symbols);
+  SecretKey.hex = keyBytes.toString('hex');
+  SecretKey.base32 = base32.encode(keyBytes).toString().replace(/=/g, '');
 
   // generate some qr codes if requested
   if (qr_codes) {
@@ -560,14 +560,18 @@ exports.generate_key = util.deprecate(function (options) {
  */
 exports.generateSecretASCII = function generateSecretASCII (length, symbols) {
   var bytes = crypto.randomBytes(length || 32);
-  var set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
+  return encodeASCII(bytes, symbols);
+};
+
+function encodeASCII (bytes, symbols) {
+  var set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghijklmnopqrstuvwxyz';
   if (symbols) {
     set += '!@#$%^&*()<>?/[]{},.:;';
   }
 
   var output = '';
   for (var i = 0, l = bytes.length; i < l; i++) {
-    output += set[Math.floor(bytes[i] / 255.0 * (set.length - 1))];
+    output += set[Math.floor(bytes[i] / 256.0 * set.length)];
   }
   return output;
 };

--- a/test/generate.js
+++ b/test/generate.js
@@ -23,8 +23,7 @@ describe('Generator tests', function () {
     assert.isUndefined(secret.google_auth_qr, 'Google Auth QR should not be returned');
 
     // check encodings
-    assert.equal(Buffer(secret.hex, 'hex').toString('ascii'), secret.ascii, 'Should have encoded correct hex string');
-    assert.equal(base32.decode(secret.base32).toString('ascii'), secret.ascii, 'Should have encoded correct base32 string');
+    assert.equal(base32.decode(secret.base32).toString('hex'), secret.hex, 'Should have encoded correct base32 string');
   });
 
   it('Generation with custom key length', function () {


### PR DESCRIPTION
Hi, thanks so much for this project! It's really helping me out. I looked over the code and found something that might be improved.

The way secrets were generated not all outcomes were equally likely. Here's wat happened:

- A number of random bytes were generated.
- Each byte was mapped to one of 83 "ascii" values (or 61 without symbols).
- (Somehow the lowercase letter "j" was left out, or it would have been 84 and 62)
- Mapping was done with _floor(byte-value / 255 * (set-length - 1))_, this caused heavy bias against the last item in the set. It should be _floor(byte-value / 256 * set-length)_. Even then there's some bias in the mapping, because the bits just don't fit, set indices 0, 21, 42, and 63 are 33.3% more likely to occur.
- That string was then encoded as hex or base32, but since only 83 (or 61) byte values were possible for each position in the source string, out of every 10 possible hex/base32 strings, only about three would be generated. That's a pretty heavy bias.

So now I do this:

- Generate a number of random bytes,
- For the hex and base32 outputs, just encode those bytes as hex and base32.
- For the ascii output, use the (slightly improved) mapping function.
- Now hex and base32 are purely unbiased, and ascii still has some bias in it, so I think it should be deprecated, or moved to base64.
- One caveat, you can no longer save the ascii output on one occassion, translate it to base32 or hex yourself, and reuse it at a later occassion. Because now the base32 and hex outputs just have more random bits stuffed in them, which are discarded for the ascii output.

I hope this is all clear! Thanks in advance for looking at this.