### PR TITLE
Use base32 for otpauth_url

### DIFF
--- a/index.js
+++ b/index.js
@@ -530,7 +530,7 @@ exports.generateSecret = function generateSecret (options) {
   // add in the Google Authenticator-compatible otpauth URL
   if (otpauth_url) {
     SecretKey.otpauth_url = exports.otpauthURL({
-      secret: SecretKey.ascii,
+      secret: SecretKey.base32,
       label: name,
       issuer: issuer
     });


### PR DESCRIPTION
Fixes https://github.com/speakeasyjs/speakeasy/issues/99